### PR TITLE
Issue#54 edit to do list name bug

### DIFF
--- a/ToDoList/Controllers/HomeController.cs
+++ b/ToDoList/Controllers/HomeController.cs
@@ -134,8 +134,9 @@ namespace ToDoList.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> EditToDoList(int id)
+        public async Task<IActionResult> EditToDoList(int id, int userId)
         {
+            ViewData["UserId"] = userId;
             TDList list = await TDListDb.GetToDoListById(_context, id);
             if (list == null)
             {

--- a/ToDoList/Views/Home/EditToDoList.cshtml
+++ b/ToDoList/Views/Home/EditToDoList.cshtml
@@ -12,6 +12,7 @@
         <form asp-action="EditToDoList">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="ListId" />
+            <input type="hidden" asp-for="UserId" />
             <div class="form-group">
                 <label asp-for="ListTitle" class="control-label"></label>
                 <input asp-for="ListTitle" class="form-control" />
@@ -25,7 +26,7 @@
 </div>
 
 <div>
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="Index">Back to Home</a>
 </div>
 
 @section Scripts {

--- a/ToDoList/Views/Home/ViewAllToDoLists.cshtml
+++ b/ToDoList/Views/Home/ViewAllToDoLists.cshtml
@@ -15,7 +15,7 @@
                     @Html.DisplayFor(modelItem => item.ListTitle)
                 </td>
                 <td>
-                    <a asp-action="EditToDoList" asp-route-id="@item.ListId">Edit Name</a> |
+                    <a asp-action="EditToDoList" asp-route-id="@item.ListId" asp-route-userId="@item.UserId">Edit Name</a> |
                     <a asp-action="Details" asp-route-id="@item.ListId">Details</a> |
                     <a asp-action="DeleteToDoList" asp-route-id="@item.ListId">Delete</a>
                 </td>


### PR DESCRIPTION
Closes #54 
The cause of the bug was as expected. The userId wasn't being passed in to the edit todo list name view, which is why it's turning the userId column in the database to null. I added an asp-route-userId attribute with the Edit Name link, so it passed in the userId to the edit view. That way, we keep the user's id tied to that todo list.